### PR TITLE
fix issue #3

### DIFF
--- a/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
+++ b/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
@@ -130,7 +130,9 @@ public class FlutterPcmSoundPlugin implements
                         mMinBufferSize,
                         AudioTrack.MODE_STREAM);
                 }
-
+                playbackSuspended = true;
+                playbackRunning = true;
+                mDidInvokeFeedCallback =false;
                 startPlaybackThread();
 
                 result.success(true);
@@ -235,6 +237,7 @@ public class FlutterPcmSoundPlugin implements
 
     private void cleanup() {
         if (mAudioTrack != null) {
+            mAudioTrack.flush();
             mAudioTrack.release();
             mAudioTrack = null;
         }
@@ -289,10 +292,11 @@ public class FlutterPcmSoundPlugin implements
 
     private void stopPlaybackThread() {
         if (playbackThread != null) {
+            playbackSuspended = false;
             playbackRunning = false;
             playbackThread.interrupt();
             try {
-                playbackThread.join();
+                playbackThread.join(1);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }


### PR DESCRIPTION
- When back then enter pcm sound screen again, some Boolean variables are uninitialized again, so we need initialize those again in setup.
- Audio Track flush is more effective in STREAM_MODE.
- Thread.join() will make others thread wait until calling thread is done, this makes the app crash, so thread.join(1) will make others thread wait only 1 millisecond to resume. Mobile app is not crashed.