### PR TITLE
Add null check

### DIFF
--- a/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
+++ b/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
@@ -270,7 +270,10 @@ public class FlutterPcmSoundPlugin implements
                     try {
                         if (mIsPlaying) {
                             while (mSamplesIsEmpty() == false) {
-                                ByteBuffer data = mSamplesPop().duplicate();
+                                ByteBuffer data = mSamplesPop();
+                                if(data != null) {
+                                    data = data.duplicate();
+                                }
                                 if (data != null && mAudioTrack != null) {
                                     mAudioTrack.write(data, data.remaining(), AudioTrack.WRITE_BLOCKING);
                                 }


### PR DESCRIPTION
FIx #5 

It seems some like this null check is necessary here. Very rare cache but happens to us some times...

```
E/AndroidRuntime( 3917): FATAL EXCEPTION: Thread-5
E/AndroidRuntime( 3917): Process: com.example.evresys_research, PID: 3917
E/AndroidRuntime( 3917): java.lang.NullPointerException: Attempt to invoke virtual method ‘java.nio.ByteBuffer java.nio.ByteBuffer.duplicate()’ on a null object reference
E/AndroidRuntime( 3917): 	at com.lib.flutter_pcm_sound.FlutterPcmSoundPlugin.lambda$startPlaybackThread$1$com-lib-flutter_pcm_sound-FlutterPcmSoundPlugin(FlutterPcmSoundPlugin.java:271)
E/AndroidRuntime( 3917): 	at com.lib.flutter_pcm_sound.FlutterPcmSoundPlugin$$ExternalSyntheticLambda1.run(Unknown Source:2)
E/AndroidRuntime( 3917): 	at java.lang.Thread.run(Thread.java:1012)
I/flutter ( 3917): [PCM] [[ OnFeedSamples ]] {remaining_frames: 0}
I/flutter ( 3917): [PCM] invoke: feed (960 samples) [0, 0, 0, 0, 0, 0] ...
```