### PR TITLE
fix: make sure setLogLevel does not hang on Android

### DIFF
--- a/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
+++ b/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
@@ -88,6 +88,7 @@ public class FlutterPcmSoundPlugin implements
         switch (call.method) {
             case "setLogLevel":
                 // Handle setLogLevel
+                result.success(true);
                 break;
             case "setup":
                 int sampleRate = call.argument("sample_rate");


### PR DESCRIPTION
Thanks for working on midi solutions for flutter. Dart melty sound font example was stuck on "initializing" on Android and I notifice setLogLevel does not do anything on Android (fine) and never returns anything (less fine). This simply make sure setLogLevel does not hang on Android