### PR TITLE
adding getAudioDevices and setAudioDevice methods for MacOs

### DIFF
--- a/ios/Classes/FlutterPcmSoundPlugin.h
+++ b/ios/Classes/FlutterPcmSoundPlugin.h
@@ -1,6 +1,7 @@
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>
+#import <CoreAudio/CoreAudio.h>
 #else
 #import <Flutter/Flutter.h>
 #endif

--- a/lib/flutter_pcm_sound.dart
+++ b/lib/flutter_pcm_sound.dart
@@ -49,6 +49,16 @@ class FlutterPcmSound {
     return;
   }
 
+  // Getting output audio volume, default volume = 1.0
+  static Future<double> getVolume() async {
+    return await _channel.invokeMethod('getVolume');
+  }
+
+  // Setting on output audio volume
+  static Future<void> setVolume(double volume) {
+    return _channel.invokeMethod('setVolume', {'volume': volume});
+  }
+
   /// setup audio
   /// 'avAudioCategory' is for iOS only,
   /// enabled by default on other platforms

--- a/lib/flutter_pcm_sound.dart
+++ b/lib/flutter_pcm_sound.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:math' as math;
 import 'dart:async';
 import 'dart:typed_data';
@@ -15,7 +16,7 @@ enum IosAudioCategory {
   soloAmbient, // same as ambient, but other apps will be muted. Other apps will be muted.
   ambient, // same as soloAmbient, but other apps are not muted.
   playback, // audio will play when phone is locked, like the music app
-  playAndRecord // 
+  playAndRecord //
 }
 
 class FlutterPcmSound {
@@ -31,13 +32,27 @@ class FlutterPcmSound {
     return await _invokeMethod('setLogLevel', {'log_level': level.index});
   }
 
+  // Getting output audio device list of operating system
+  static Future<List<String>> getAudioDevices() async {
+    if (Platform.isMacOS) {
+      final List<dynamic> devices = await _channel.invokeMethod('getAudioDevices');
+      return devices.cast<String>();
+    }
+    return [];
+  }
+
+  // Setting on output audio device at operating system for player
+  static Future<void> setAudioDevice(String deviceName) async {
+    if (Platform.isMacOS) {
+      await _channel.invokeMethod('setAudioDevice', {'deviceName': deviceName});
+    }
+    return;
+  }
+
   /// setup audio
   /// 'avAudioCategory' is for iOS only,
   /// enabled by default on other platforms
-  static Future<void> setup(
-      {required int sampleRate,
-      required int channelCount,
-      IosAudioCategory iosAudioCategory = IosAudioCategory.playback}) async {
+  static Future<void> setup({required int sampleRate, required int channelCount, IosAudioCategory iosAudioCategory = IosAudioCategory.playback}) async {
     return await _invokeMethod('setup', {
       'sample_rate': sampleRate,
       'num_channels': channelCount,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_pcm_sound
 description: Send real-time PCM audio (16-bit integer) to your device speakers
-version: 3.1.3
+version: 3.2.3
 homepage: https://github.com/chipweinberger/flutter_pcm_sound
 
 environment:


### PR DESCRIPTION
1. adding selecting output audio device for player in some methods getAudioDevices and setAudioDevice for MacOs
2. resolving problem "I've noticed that native realisation changes common output channel. It won't exactly what we want."
3. checking is it works right