### PR TITLE
Upgrade Java compatibility to version 17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,8 +7,8 @@ android {
     compileSdkVersion 33
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {


### PR DESCRIPTION
See [this flutter issue](https://github.com/flutter/flutter/issues/156111) and [this PR](https://github.com/flutter/flutter/pull/160349) for context.

This ensures that no warnings are emitted when building this package with Android Studio Ladybug / Java 21.

After this change Java 17 is used for source and target compatibility, just like in the [official packages](https://github.com/flutter/packages/blob/2cd921cb5b95ec32408509e5dcb540b67ed41bbc/packages/url_launcher/url_launcher_android/android/build.gradle#L37).