### PR TITLE
feat(android): add androidAudioUsage parameter to setup()

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
+++ b/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
@@ -90,6 +90,21 @@ public class FlutterPcmSoundPlugin implements
                 case "setup": {
                     int sampleRate = call.argument("sample_rate");
                     mNumChannels = call.argument("num_channels");
+                    String androidAudioUsage = call.argument("android_audio_usage");
+
+                    // Resolve audio attributes from the requested usage.
+                    // voiceCommunication enables hardware AEC so the microphone does not
+                    // capture speaker output during bidirectional (bidi) streaming.
+                    boolean isVoice = "voiceCommunication".equals(androidAudioUsage);
+                    int audioUsage = isVoice
+                        ? AudioAttributes.USAGE_VOICE_COMMUNICATION
+                        : AudioAttributes.USAGE_MEDIA;
+                    int contentType = isVoice
+                        ? AudioAttributes.CONTENT_TYPE_SPEECH
+                        : AudioAttributes.CONTENT_TYPE_MUSIC;
+                    int legacyStreamType = isVoice
+                        ? AudioManager.STREAM_VOICE_CALL
+                        : AudioManager.STREAM_MUSIC;
 
                     // Cleanup existing resources if any
                     if (mAudioTrack != null) {
@@ -111,8 +126,8 @@ public class FlutterPcmSoundPlugin implements
                     if (Build.VERSION.SDK_INT >= 23) { // Android 6 (Marshmallow) and above
                         mAudioTrack = new AudioTrack.Builder()
                             .setAudioAttributes(new AudioAttributes.Builder()
-                                    .setUsage(AudioAttributes.USAGE_MEDIA)
-                                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                                    .setUsage(audioUsage)
+                                    .setContentType(contentType)
                                     .build())
                             .setAudioFormat(new AudioFormat.Builder()
                                     .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
@@ -124,7 +139,7 @@ public class FlutterPcmSoundPlugin implements
                             .build();
                     } else {
                         mAudioTrack = new AudioTrack(
-                            AudioManager.STREAM_MUSIC,
+                            legacyStreamType,
                             sampleRate,
                             channelConfig,
                             AudioFormat.ENCODING_PCM_16BIT,

--- a/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
+++ b/android/src/main/java/com/lib/flutter_pcm_sound/FlutterPcmSoundPlugin.java
@@ -91,20 +91,12 @@ public class FlutterPcmSoundPlugin implements
                     int sampleRate = call.argument("sample_rate");
                     mNumChannels = call.argument("num_channels");
                     String androidAudioUsage = call.argument("android_audio_usage");
+                    String androidAudioContentType = call.argument("android_audio_content_type");
+                    String androidLegacyStreamType = call.argument("android_legacy_stream_type");
 
-                    // Resolve audio attributes from the requested usage.
-                    // voiceCommunication enables hardware AEC so the microphone does not
-                    // capture speaker output during bidirectional (bidi) streaming.
-                    boolean isVoice = "voiceCommunication".equals(androidAudioUsage);
-                    int audioUsage = isVoice
-                        ? AudioAttributes.USAGE_VOICE_COMMUNICATION
-                        : AudioAttributes.USAGE_MEDIA;
-                    int contentType = isVoice
-                        ? AudioAttributes.CONTENT_TYPE_SPEECH
-                        : AudioAttributes.CONTENT_TYPE_MUSIC;
-                    int legacyStreamType = isVoice
-                        ? AudioManager.STREAM_VOICE_CALL
-                        : AudioManager.STREAM_MUSIC;
+                    int audioUsage = resolveAudioUsage(androidAudioUsage);
+                    int contentType = resolveAudioContentType(androidAudioContentType);
+                    int legacyStreamType = resolveLegacyStreamType(androidLegacyStreamType);
 
                     // Cleanup existing resources if any
                     if (mAudioTrack != null) {
@@ -315,5 +307,55 @@ public class FlutterPcmSoundPlugin implements
             offset += length;
         }
         return chunks;
+    }
+
+    private int resolveAudioUsage(String value) {
+        if (value == null) return AudioAttributes.USAGE_MEDIA;
+        switch (value) {
+            case "unknown":                      return AudioAttributes.USAGE_UNKNOWN;
+            case "voiceCommunication":           return AudioAttributes.USAGE_VOICE_COMMUNICATION;
+            case "voiceCommunicationSignalling": return AudioAttributes.USAGE_VOICE_COMMUNICATION_SIGNALLING;
+            case "alarm":                        return AudioAttributes.USAGE_ALARM;
+            case "notification":                 return AudioAttributes.USAGE_NOTIFICATION;
+            case "notificationRingtone":         return AudioAttributes.USAGE_NOTIFICATION_RINGTONE;
+            case "notificationEvent":            return AudioAttributes.USAGE_NOTIFICATION_EVENT;
+            case "assistanceAccessibility":      return AudioAttributes.USAGE_ASSISTANCE_ACCESSIBILITY;
+            case "assistanceNavigationGuidance": return AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE;
+            case "assistanceSonification":       return AudioAttributes.USAGE_ASSISTANCE_SONIFICATION;
+            case "game":                         return AudioAttributes.USAGE_GAME;
+            case "assistant":                    return AudioAttributes.USAGE_ASSISTANT;
+            case "media":
+            default:                             return AudioAttributes.USAGE_MEDIA;
+        }
+    }
+
+    private int resolveAudioContentType(String value) {
+        if (value == null) return AudioAttributes.CONTENT_TYPE_MUSIC;
+        switch (value) {
+            case "unknown":      return AudioAttributes.CONTENT_TYPE_UNKNOWN;
+            case "speech":       return AudioAttributes.CONTENT_TYPE_SPEECH;
+            case "movie":        return AudioAttributes.CONTENT_TYPE_MOVIE;
+            case "sonification": return AudioAttributes.CONTENT_TYPE_SONIFICATION;
+            case "music":
+            default:             return AudioAttributes.CONTENT_TYPE_MUSIC;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private int resolveLegacyStreamType(String value) {
+        if (value == null) return AudioManager.STREAM_MUSIC;
+        switch (value) {
+            case "voiceCall":    return AudioManager.STREAM_VOICE_CALL;
+            case "system":       return AudioManager.STREAM_SYSTEM;
+            case "ring":         return AudioManager.STREAM_RING;
+            case "alarm":        return AudioManager.STREAM_ALARM;
+            case "notification": return AudioManager.STREAM_NOTIFICATION;
+            case "dtmf":         return AudioManager.STREAM_DTMF;
+            case "accessibility":
+                if (Build.VERSION.SDK_INT >= 26) return AudioManager.STREAM_ACCESSIBILITY;
+                return AudioManager.STREAM_MUSIC;
+            case "music":
+            default:             return AudioManager.STREAM_MUSIC;
+        }
     }
 }

--- a/lib/flutter_pcm_sound.dart
+++ b/lib/flutter_pcm_sound.dart
@@ -20,13 +20,40 @@ enum IosAudioCategory {
 
 // Android Documentation: https://developer.android.com/reference/android/media/AudioAttributes
 enum AndroidAudioUsage {
-  /// Default. Music, podcasts, videos. Uses USAGE_MEDIA / STREAM_MUSIC.
-  media,
+  unknown,                       // USAGE_UNKNOWN
+  media,                         // USAGE_MEDIA (default)
+  voiceCommunication,            // USAGE_VOICE_COMMUNICATION
+  voiceCommunicationSignalling,  // USAGE_VOICE_COMMUNICATION_SIGNALLING
+  alarm,                         // USAGE_ALARM
+  notification,                  // USAGE_NOTIFICATION
+  notificationRingtone,          // USAGE_NOTIFICATION_RINGTONE
+  notificationEvent,             // USAGE_NOTIFICATION_EVENT
+  assistanceAccessibility,       // USAGE_ASSISTANCE_ACCESSIBILITY
+  assistanceNavigationGuidance,  // USAGE_ASSISTANCE_NAVIGATION_GUIDANCE
+  assistanceSonification,        // USAGE_ASSISTANCE_SONIFICATION
+  game,                          // USAGE_GAME
+  assistant,                     // USAGE_ASSISTANT
+}
 
-  /// VoIP and voice assistants. Uses USAGE_VOICE_COMMUNICATION / STREAM_VOICE_CALL.
-  /// Activates hardware Acoustic Echo Cancellation (AEC) so the microphone
-  /// does not capture speaker output during bidirectional streaming.
-  voiceCommunication,
+// Android Documentation: https://developer.android.com/reference/android/media/AudioAttributes
+enum AndroidAudioContentType {
+  unknown,      // CONTENT_TYPE_UNKNOWN
+  speech,       // CONTENT_TYPE_SPEECH
+  music,        // CONTENT_TYPE_MUSIC (default)
+  movie,        // CONTENT_TYPE_MOVIE
+  sonification, // CONTENT_TYPE_SONIFICATION
+}
+
+// Android Documentation: https://developer.android.com/reference/android/media/AudioManager
+enum AndroidLegacyStreamType {
+  voiceCall,    // STREAM_VOICE_CALL
+  system,       // STREAM_SYSTEM
+  ring,         // STREAM_RING
+  music,        // STREAM_MUSIC (default)
+  alarm,        // STREAM_ALARM
+  notification, // STREAM_NOTIFICATION
+  dtmf,         // STREAM_DTMF
+  accessibility, // STREAM_ACCESSIBILITY (API 26+)
 }
 
 class FlutterPcmSound {
@@ -46,21 +73,26 @@ class FlutterPcmSound {
 
   /// setup audio
   /// [iosAudioCategory] is iOS only.
-  /// [androidAudioUsage] is Android only — use [AndroidAudioUsage.voiceCommunication]
-  /// for VoIP / voice-assistant apps to activate hardware AEC.
+  /// [androidAudioUsage] is Android only. See [AndroidAudioUsage].
+  /// [androidAudioContentType] is Android only. See [AndroidAudioContentType].
+  /// [androidLegacyStreamType] is Android only, used on API < 23. See [AndroidLegacyStreamType].
   static Future<void> setup(
       {required int sampleRate,
       required int channelCount,
       IosAudioCategory iosAudioCategory = IosAudioCategory.playback,
       bool iosAllowBackgroundAudio = false,
       AndroidAudioUsage androidAudioUsage = AndroidAudioUsage.media,
+      AndroidAudioContentType androidAudioContentType = AndroidAudioContentType.music,
+      AndroidLegacyStreamType androidLegacyStreamType = AndroidLegacyStreamType.music,
       }) async {
     return await _invokeMethod('setup', {
       'sample_rate': sampleRate,
       'num_channels': channelCount,
       'ios_audio_category': iosAudioCategory.name,
-      'ios_allow_background_audio' : iosAllowBackgroundAudio,
+      'ios_allow_background_audio': iosAllowBackgroundAudio,
       'android_audio_usage': androidAudioUsage.name,
+      'android_audio_content_type': androidAudioContentType.name,
+      'android_legacy_stream_type': androidLegacyStreamType.name,
     });
   }
 

--- a/lib/flutter_pcm_sound.dart
+++ b/lib/flutter_pcm_sound.dart
@@ -18,6 +18,17 @@ enum IosAudioCategory {
   playAndRecord //
 }
 
+// Android Documentation: https://developer.android.com/reference/android/media/AudioAttributes
+enum AndroidAudioUsage {
+  /// Default. Music, podcasts, videos. Uses USAGE_MEDIA / STREAM_MUSIC.
+  media,
+
+  /// VoIP and voice assistants. Uses USAGE_VOICE_COMMUNICATION / STREAM_VOICE_CALL.
+  /// Activates hardware Acoustic Echo Cancellation (AEC) so the microphone
+  /// does not capture speaker output during bidirectional streaming.
+  voiceCommunication,
+}
+
 class FlutterPcmSound {
   static const MethodChannel _channel = const MethodChannel('flutter_pcm_sound/methods');
 
@@ -34,19 +45,22 @@ class FlutterPcmSound {
   }
 
   /// setup audio
-  /// 'avAudioCategory' is for iOS only,
-  /// enabled by default on other platforms
+  /// [iosAudioCategory] is iOS only.
+  /// [androidAudioUsage] is Android only — use [AndroidAudioUsage.voiceCommunication]
+  /// for VoIP / voice-assistant apps to activate hardware AEC.
   static Future<void> setup(
       {required int sampleRate,
       required int channelCount,
       IosAudioCategory iosAudioCategory = IosAudioCategory.playback,
       bool iosAllowBackgroundAudio = false,
+      AndroidAudioUsage androidAudioUsage = AndroidAudioUsage.media,
       }) async {
     return await _invokeMethod('setup', {
       'sample_rate': sampleRate,
       'num_channels': channelCount,
       'ios_audio_category': iosAudioCategory.name,
       'ios_allow_background_audio' : iosAllowBackgroundAudio,
+      'android_audio_usage': androidAudioUsage.name,
     });
   }
 


### PR DESCRIPTION
Mirrors the existing iosAudioCategory API for Android. Passing AndroidAudioUsage.voiceCommunication configures AudioTrack with USAGE_VOICE_COMMUNICATION / CONTENT_TYPE_SPEECH / STREAM_VOICE_CALL, which activates hardware Acoustic Echo Cancellation (AEC) on devices that support it.

This is needed for VoIP and voice-assistant apps that stream microphone audio and speaker output simultaneously (bidi streaming). Without this, the microphone captures the speaker output and the server-side VAD treats it as user speech.

Default remains AndroidAudioUsage.media — no breaking change.